### PR TITLE
add auto-approve label

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor ==
-          'dependabot-preview[bot]'
+        if: github.actor == 'pahud' || contains(
+          github.event.pull_request.labels.*.name, 'auto-approve')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/projenyarnupgrade.yml
+++ b/.github/workflows/projenyarnupgrade.yml
@@ -23,4 +23,4 @@ jobs:
           branch: auto/projen-upgrade
           title: "chore: upgrade projen and yarn"
           body: This PR upgrades projen and yarn upgrade to the latest version
-          labels: auto-merge
+          labels: auto-merge,auto-approve

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -58,7 +58,7 @@ autoApprove.addJobs({
     [
       {
         uses: 'hmarr/auto-approve-action@v2.0.0',
-        if: "github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'",
+        if: "github.actor == 'pahud' || contains( github.event.pull_request.labels.*.name, 'auto-approve')",
         with: {
           'github-token': '${{ secrets.GITHUB_TOKEN }}',
         },
@@ -100,7 +100,7 @@ workflow.addJobs({
           'branch': 'auto/projen-upgrade',
           'title': 'chore: upgrade projen and yarn',
           'body': 'This PR upgrades projen and yarn upgrade to the latest version',
-          'labels': 'auto-merge',
+          'labels': 'auto-merge,auto-approve', 
         },
       },
     ],


### PR DESCRIPTION
To automate the periodical version bump PRs, we need apply the `auto-approve` label.