### PR TITLE
Update Keycloak version to 15.0.2

### DIFF
--- a/src/keycloak.ts
+++ b/src/keycloak.ts
@@ -29,7 +29,7 @@ const AURORA_SERVERLESS_SUPPORTED_REGIONS = [
   'cn-northwest-1',
 ];
 
-const KEYCLOAK_VERSION = '12.0.4';
+const KEYCLOAK_VERSION = '15.0.2';
 
 interface dockerImageMap {
   'aws': string;

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -618,7 +618,7 @@ Object {
               },
             ],
             "Essential": true,
-            "Image": "jboss/keycloak:12.0.4",
+            "Image": "jboss/keycloak:15.0.2",
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
               "Options": Object {


### PR DESCRIPTION
This PR will update Keycloak image's version to 15.0.2, which is the latest version.

refs: 

- https://github.com/keycloak/keycloak/releases/tag/15.0.2
- https://quay.io/repository/keycloak/keycloak?tab=tags