### PR TITLE
Fix/service typo

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,7 +16,7 @@ Name|Description
 ----|-----------
 [AutoScaleTask](#cdk-keycloak-autoscaletask)|The ECS task autoscaling definition.
 [ContainerServiceProps](#cdk-keycloak-containerserviceprops)|*No description*
-[DatabaseCofig](#cdk-keycloak-databasecofig)|Database configuration.
+[DatabaseConfig](#cdk-keycloak-databaseconfig)|Database configuration.
 [DatabaseProps](#cdk-keycloak-databaseprops)|*No description*
 [KeyCloakProps](#cdk-keycloak-keycloakprops)|*No description*
 
@@ -132,7 +132,7 @@ new KeyCloak(scope: Construct, id: string, props: KeyCloakProps)
   * **keycloakVersion** (<code>[KeycloakVersion](#cdk-keycloak-keycloakversion)</code>)  The Keycloak version for the cluster. 
   * **auroraServerless** (<code>boolean</code>)  Whether to use aurora serverless. __*Default*__: false
   * **autoScaleTask** (<code>[AutoScaleTask](#cdk-keycloak-autoscaletask)</code>)  Autoscaling for the ECS Service. __*Default*__: no ecs service autoscaling
-  * **backupRetention** (<code>[Duration](#aws-cdk-core-duration)</code>)  database backup retension. __*Default*__: 7 days
+  * **backupRetention** (<code>[Duration](#aws-cdk-core-duration)</code>)  database backup retention. __*Default*__: 7 days
   * **bastion** (<code>boolean</code>)  Create a bastion host for debugging or trouble-shooting. __*Default*__: false
   * **clusterEngine** (<code>[IClusterEngine](#aws-cdk-aws-rds-iclusterengine)</code>)  The database cluster engine. __*Default*__: rds.AuroraMysqlEngineVersion.VER_2_09_1
   * **databaseInstanceType** (<code>[InstanceType](#aws-cdk-aws-ec2-instancetype)</code>)  Database instance type. __*Default*__: r5.large
@@ -170,7 +170,7 @@ addDatabase(props: DatabaseProps): Database
 * **props** (<code>[DatabaseProps](#cdk-keycloak-databaseprops)</code>)  *No description*
   * **vpc** (<code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code>)  The VPC for the database. 
   * **auroraServerless** (<code>boolean</code>)  enable aurora serverless. __*Default*__: false
-  * **backupRetention** (<code>[Duration](#aws-cdk-core-duration)</code>)  database backup retension. __*Default*__: 7 days
+  * **backupRetention** (<code>[Duration](#aws-cdk-core-duration)</code>)  database backup retention. __*Default*__: 7 days
   * **clusterEngine** (<code>[IClusterEngine](#aws-cdk-aws-rds-iclusterengine)</code>)  The database cluster engine. __*Default*__: rds.AuroraMysqlEngineVersion.VER_2_09_1
   * **databaseSubnets** (<code>[SubnetSelection](#aws-cdk-aws-ec2-subnetselection)</code>)  VPC subnets for database. __*Optional*__
   * **instanceEngine** (<code>[IInstanceEngine](#aws-cdk-aws-rds-iinstanceengine)</code>)  The database instance engine. __*Default*__: MySQL 8.0.21
@@ -283,7 +283,7 @@ Name | Type | Description
 
 
 
-## struct DatabaseCofig  <a id="cdk-keycloak-databasecofig"></a>
+## struct DatabaseConfig  <a id="cdk-keycloak-databaseconfig"></a>
 
 
 Database configuration.
@@ -292,9 +292,9 @@ Database configuration.
 
 Name | Type | Description 
 -----|------|-------------
-**connections** | <code>[Connections](#aws-cdk-aws-ec2-connections)</code> | The database connnections.
+**connections** | <code>[Connections](#aws-cdk-aws-ec2-connections)</code> | The database connections.
 **endpoint** | <code>string</code> | The endpoint address for the database.
-**identifier** | <code>string</code> | The databasae identifier.
+**identifier** | <code>string</code> | The database identifier.
 **secret** | <code>[ISecret](#aws-cdk-aws-secretsmanager-isecret)</code> | The database secret.
 
 
@@ -310,7 +310,7 @@ Name | Type | Description
 -----|------|-------------
 **vpc** | <code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code> | The VPC for the database.
 **auroraServerless**? | <code>boolean</code> | enable aurora serverless.<br/>__*Default*__: false
-**backupRetention**? | <code>[Duration](#aws-cdk-core-duration)</code> | database backup retension.<br/>__*Default*__: 7 days
+**backupRetention**? | <code>[Duration](#aws-cdk-core-duration)</code> | database backup retention.<br/>__*Default*__: 7 days
 **clusterEngine**? | <code>[IClusterEngine](#aws-cdk-aws-rds-iclusterengine)</code> | The database cluster engine.<br/>__*Default*__: rds.AuroraMysqlEngineVersion.VER_2_09_1
 **databaseSubnets**? | <code>[SubnetSelection](#aws-cdk-aws-ec2-subnetselection)</code> | VPC subnets for database.<br/>__*Optional*__
 **instanceEngine**? | <code>[IInstanceEngine](#aws-cdk-aws-rds-iinstanceengine)</code> | The database instance engine.<br/>__*Default*__: MySQL 8.0.21
@@ -332,7 +332,7 @@ Name | Type | Description
 **keycloakVersion** | <code>[KeycloakVersion](#cdk-keycloak-keycloakversion)</code> | The Keycloak version for the cluster.
 **auroraServerless**? | <code>boolean</code> | Whether to use aurora serverless.<br/>__*Default*__: false
 **autoScaleTask**? | <code>[AutoScaleTask](#cdk-keycloak-autoscaletask)</code> | Autoscaling for the ECS Service.<br/>__*Default*__: no ecs service autoscaling
-**backupRetention**? | <code>[Duration](#aws-cdk-core-duration)</code> | database backup retension.<br/>__*Default*__: 7 days
+**backupRetention**? | <code>[Duration](#aws-cdk-core-duration)</code> | database backup retention.<br/>__*Default*__: 7 days
 **bastion**? | <code>boolean</code> | Create a bastion host for debugging or trouble-shooting.<br/>__*Default*__: false
 **clusterEngine**? | <code>[IClusterEngine](#aws-cdk-aws-rds-iclusterengine)</code> | The database cluster engine.<br/>__*Default*__: rds.AuroraMysqlEngineVersion.VER_2_09_1
 **databaseInstanceType**? | <code>[InstanceType](#aws-cdk-aws-ec2-instancetype)</code> | Database instance type.<br/>__*Default*__: r5.large

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ new KeyCloak(stack, 'KeyCloak', {
 });
 ```
 
-To specify any other verion not defined in the construct, use `KeycloakVersion.of('x.x.x')`. This allows you to specify any new version as soon as it's available. However, as new versions will not always be tested and validated with this construct library, make sure you fully backup and test before you use any new version in the production environment.
+To specify any other version not defined in the construct, use `KeycloakVersion.of('x.x.x')`. This allows you to specify any new version as soon as it's available. However, as new versions will not always be tested and validated with this construct library, make sure you fully backup and test before you use any new version in the production environment.
 
 
 # Aurora Serverless support
 
-The `KeyCloak` construct provisions the **Amaozn RDS cluster for MySQL** with **2** database instances under the hood, to opt in **Amazon Aurora Serverless**, use `auroraServerless` to opt in Amazon Aurora Serverless cluster. Please note only some regions are supported, check [Supported features in Amazon Aurora by AWS Region and Aurora DB engine](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.AuroraFeaturesRegionsDBEngines.grids.html) for availability.
+The `KeyCloak` construct provisions the **Amazon RDS cluster for MySQL** with **2** database instances under the hood, to opt in **Amazon Aurora Serverless**, use `auroraServerless` to opt in Amazon Aurora Serverless cluster. Please note only some regions are supported, check [Supported features in Amazon Aurora by AWS Region and Aurora DB engine](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.AuroraFeaturesRegionsDBEngines.grids.html) for availability.
 
 ```ts
 new KeyCloak(stack, 'KeyCloak', {
@@ -58,7 +58,7 @@ Behind the scene, a default RDS cluster for MySQL with 2 database instances will
 To create single RDS instance for your testing or development environment, use `singleDbInstance` to turn on the
 single db instance deployment.
 
-Plesae note this is not recommended for production environment.
+Please note this is not recommended for production environment.
 
 ```ts
 new KeyCloak(stack, 'KeyCloak', {

--- a/src/keycloak.ts
+++ b/src/keycloak.ts
@@ -181,7 +181,7 @@ export interface KeyCloakProps {
    */
   readonly singleDbInstance?: boolean;
   /**
-   * database backup retension
+   * database backup retention
    *
    * @default - 7 days
    */
@@ -246,7 +246,7 @@ export class KeyCloak extends cdk.Construct {
     return new Database(this, 'Database', props);
   }
   public addKeyCloakContainerService(props: ContainerServiceProps) {
-    return new ContainerService(this, 'KeyCloakContainerSerivce', props);
+    return new ContainerService(this, 'KeyCloakContainerService', props);
   }
   private _generateKeycloakSecret(): secretsmanager.ISecret {
     return new secretsmanager.Secret(this, 'KCSecret', {
@@ -301,7 +301,7 @@ export interface DatabaseProps {
    */
   readonly singleDbInstance?: boolean;
   /**
-   * database backup retension
+   * database backup retention
    *
    * @default - 7 days
    */
@@ -311,13 +311,13 @@ export interface DatabaseProps {
 /**
  * Database configuration
  */
-export interface DatabaseCofig {
+export interface DatabaseConfig {
   /**
    * The database secret.
    */
   readonly secret: secretsmanager.ISecret;
   /**
-   * The database connnections.
+   * The database connections.
    */
   readonly connections: ec2.Connections;
   /**
@@ -325,7 +325,7 @@ export interface DatabaseCofig {
    */
   readonly endpoint: string;
   /**
-   * The databasae identifier.
+   * The database identifier.
    */
   readonly identifier: string;
 }
@@ -358,7 +358,7 @@ export class Database extends cdk.Construct {
     printOutput(this, 'clusterEndpointHostname', this.clusterEndpointHostname);
     printOutput(this, 'clusterIdentifier', this.clusterIdentifier);
   }
-  private _createRdsInstance(props: DatabaseProps): DatabaseCofig {
+  private _createRdsInstance(props: DatabaseProps): DatabaseConfig {
     const dbInstance = new rds.DatabaseInstance(this, 'DBInstance', {
       vpc: props.vpc,
       databaseName: 'keycloak',
@@ -382,7 +382,7 @@ export class Database extends cdk.Construct {
     };
   }
   // create a RDS for MySQL DB cluster
-  private _createRdsCluster(props: DatabaseProps): DatabaseCofig {
+  private _createRdsCluster(props: DatabaseProps): DatabaseConfig {
     const dbCluster = new rds.DatabaseCluster(this, 'DBCluster', {
       engine: props.clusterEngine ?? rds.DatabaseClusterEngine.auroraMysql({
         version: rds.AuroraMysqlEngineVersion.VER_2_09_1,
@@ -409,7 +409,7 @@ export class Database extends cdk.Construct {
       secret: dbCluster.secret!,
     };
   }
-  private _createServerlessCluster(props: DatabaseProps): DatabaseCofig {
+  private _createServerlessCluster(props: DatabaseProps): DatabaseConfig {
     const dbCluster = new rds.ServerlessCluster(this, 'AuroraServerlessCluster', {
       engine: rds.DatabaseClusterEngine.AURORA_MYSQL,
       vpc: props.vpc,

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -22,7 +22,7 @@ Object {
         "Ref": "KeyCloakDatabaseAuroraServerlessClusterDB73D16F",
       },
     },
-    "KeyCloakKeyCloakContainerSerivceEndpointURL9C81E19A": Object {
+    "KeyCloakKeyCloakContainerServiceEndpointURL80FE66F9": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
@@ -30,7 +30,7 @@ Object {
             "https://",
             Object {
               "Fn::GetAtt": Array [
-                "KeyCloakKeyCloakContainerSerivceALBE100B67D",
+                "KeyCloakKeyCloakContainerServiceALBF769E7D3",
                 "DNSName",
               ],
             },
@@ -155,9 +155,9 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4FIndirectPortF24A4E85": Object {
+    "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FEDIndirectPortCEAF978C": Object {
       "Properties": Object {
-        "Description": "from keycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F:{IndirectPort}",
+        "Description": "from keycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED:{IndirectPort}",
         "FromPort": Object {
           "Fn::GetAtt": Array [
             "KeyCloakDatabaseAuroraServerlessClusterDB73D16F",
@@ -173,7 +173,7 @@ Object {
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -213,7 +213,7 @@ Object {
       },
       "Type": "AWS::SecretsManager::Secret",
     },
-    "KeyCloakKeyCloakContainerSerivceALBE100B67D": Object {
+    "KeyCloakKeyCloakContainerServiceALBF769E7D3": Object {
       "DependsOn": Array [
         "KeyCloakVpcPublicSubnet1DefaultRoute438FBE69",
         "KeyCloakVpcPublicSubnet2DefaultRouteCFC19404",
@@ -229,7 +229,7 @@ Object {
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
-              "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6",
+              "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F",
               "GroupId",
             ],
           },
@@ -246,7 +246,7 @@ Object {
       },
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
     },
-    "KeyCloakKeyCloakContainerSerivceALBHttpsListener140F85B9": Object {
+    "KeyCloakKeyCloakContainerServiceALBHttpsListener6BFECEEA": Object {
       "Properties": Object {
         "Certificates": Array [
           Object {
@@ -256,20 +256,20 @@ Object {
         "DefaultActions": Array [
           Object {
             "TargetGroupArn": Object {
-              "Ref": "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C",
+              "Ref": "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774",
             },
             "Type": "forward",
           },
         ],
         "LoadBalancerArn": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceALBE100B67D",
+          "Ref": "KeyCloakKeyCloakContainerServiceALBF769E7D3",
         },
         "Port": 443,
         "Protocol": "HTTPS",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
-    "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C": Object {
+    "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774": Object {
       "Properties": Object {
         "Port": 8443,
         "Protocol": "HTTPS",
@@ -298,9 +298,9 @@ Object {
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6": Object {
+    "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F": Object {
       "Properties": Object {
-        "GroupDescription": "Automatically created Security Group for ELB keycloakdemoKeyCloakKeyCloakContainerSerivceALBA5C1F684",
+        "GroupDescription": "Automatically created Security Group for ELB keycloakdemoKeyCloakKeyCloakContainerServiceALBB2622B2D",
         "SecurityGroupIngress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -316,19 +316,19 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "KeyCloakKeyCloakContainerSerivceALBSecurityGrouptokeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F84431D27BEE9": Object {
+    "KeyCloakKeyCloakContainerServiceALBSecurityGrouptokeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED8443B9DE516C": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "FromPort": 8443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6",
+            "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F",
             "GroupId",
           ],
         },
@@ -337,25 +337,14 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "KeyCloakKeyCloakContainerSerivceClusterA18E44FF": Object {
-      "Type": "AWS::ECS::Cluster",
-    },
-    "KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "RetentionInDays": 30,
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "KeyCloakKeyCloakContainerSerivceService79D3F427": Object {
+    "KeyCloakKeyCloakContainerServiceB78EDF48": Object {
       "DependsOn": Array [
-        "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C",
-        "KeyCloakKeyCloakContainerSerivceALBHttpsListener140F85B9",
+        "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774",
+        "KeyCloakKeyCloakContainerServiceALBHttpsListener6BFECEEA",
       ],
       "Properties": Object {
         "Cluster": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceClusterA18E44FF",
+          "Ref": "KeyCloakKeyCloakContainerServiceCluster4583BCAE",
         },
         "DeploymentConfiguration": Object {
           "MaximumPercent": 200,
@@ -370,7 +359,7 @@ Object {
             "ContainerName": "keycloak",
             "ContainerPort": 8443,
             "TargetGroupArn": Object {
-              "Ref": "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C",
+              "Ref": "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774",
             },
           },
         ],
@@ -380,7 +369,7 @@ Object {
             "SecurityGroups": Array [
               Object {
                 "Fn::GetAtt": Array [
-                  "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+                  "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
                   "GroupId",
                 ],
               },
@@ -396,14 +385,25 @@ Object {
           },
         },
         "TaskDefinition": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceTaskDef30C9533A",
+          "Ref": "KeyCloakKeyCloakContainerServiceTaskDef6AD61714",
         },
       },
       "Type": "AWS::ECS::Service",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D": Object {
+    "KeyCloakKeyCloakContainerServiceCluster4583BCAE": Object {
+      "Type": "AWS::ECS::Cluster",
+    },
+    "KeyCloakKeyCloakContainerServiceLogGroup770A4A22": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "GroupDescription": "keycloak-demo/KeyCloak/KeyCloakContainerSerivce/Service/SecurityGroup",
+        "RetentionInDays": 30,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A": Object {
+      "Properties": Object {
+        "GroupDescription": "keycloak-demo/KeyCloak/KeyCloakContainerService/Service/SecurityGroup",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -417,20 +417,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceALBSecurityGroup2467C3338443866EBF70": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceALBSecurityGroup67E092F7844342691A3B": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "FromPort": 8443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6",
+            "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F",
             "GroupId",
           ],
         },
@@ -438,20 +438,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F57600A05C613E": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED576009361FCC7": Object {
       "Properties": Object {
         "Description": "kc jgroups-tcp-fd",
         "FromPort": 57600,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -459,20 +459,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F76000EB755EF": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED760084F83EAB": Object {
       "Properties": Object {
         "Description": "kc jgroups-tcp",
         "FromPort": 7600,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -480,20 +480,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4FUDP5420084C20A28": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FEDUDP54200C13840AE": Object {
       "Properties": Object {
         "Description": "kc jgroups-udp-fd",
         "FromPort": 54200,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "udp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -501,20 +501,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4FUDP552001CE4EB13": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FEDUDP55200DCB1BF9D": Object {
       "Properties": Object {
         "Description": "kc jgroups-udp",
         "FromPort": 55200,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "udp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -522,7 +522,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceTaskCountTarget0EDF86B3": Object {
+    "KeyCloakKeyCloakContainerServiceTaskCountTarget95167BD4": Object {
       "Properties": Object {
         "MaxCapacity": 10,
         "MinCapacity": 2,
@@ -532,12 +532,12 @@ Object {
             Array [
               "service/",
               Object {
-                "Ref": "KeyCloakKeyCloakContainerSerivceClusterA18E44FF",
+                "Ref": "KeyCloakKeyCloakContainerServiceCluster4583BCAE",
               },
               "/",
               Object {
                 "Fn::GetAtt": Array [
-                  "KeyCloakKeyCloakContainerSerivceService79D3F427",
+                  "KeyCloakKeyCloakContainerServiceB78EDF48",
                   "Name",
                 ],
               },
@@ -565,12 +565,12 @@ Object {
       },
       "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceTaskCountTargetCpuScaling1480DC0B": Object {
+    "KeyCloakKeyCloakContainerServiceTaskCountTargetCpuScalingB44CF87F": Object {
       "Properties": Object {
-        "PolicyName": "keycloakdemoKeyCloakKeyCloakContainerSerivceServiceTaskCountTargetCpuScaling6EF32B2A",
+        "PolicyName": "keycloakdemoKeyCloakKeyCloakContainerServiceTaskCountTargetCpuScaling8EE194F1",
         "PolicyType": "TargetTrackingScaling",
         "ScalingTargetId": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceServiceTaskCountTarget0EDF86B3",
+          "Ref": "KeyCloakKeyCloakContainerServiceTaskCountTarget95167BD4",
         },
         "TargetTrackingScalingPolicyConfiguration": Object {
           "PredefinedMetricSpecification": Object {
@@ -581,7 +581,7 @@ Object {
       },
       "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
     },
-    "KeyCloakKeyCloakContainerSerivceTaskDef30C9533A": Object {
+    "KeyCloakKeyCloakContainerServiceTaskDef6AD61714": Object {
       "Properties": Object {
         "ContainerDefinitions": Array [
           Object {
@@ -626,7 +626,7 @@ Object {
               "LogDriver": "awslogs",
               "Options": Object {
                 "awslogs-group": Object {
-                  "Ref": "KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE",
+                  "Ref": "KeyCloakKeyCloakContainerServiceLogGroup770A4A22",
                 },
                 "awslogs-region": "us-east-1",
                 "awslogs-stream-prefix": "keycloak",
@@ -704,11 +704,11 @@ Object {
         "Cpu": "4096",
         "ExecutionRoleArn": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceTaskRole0658CED2",
+            "KeyCloakKeyCloakContainerServiceTaskRoleE227375A",
             "Arn",
           ],
         },
-        "Family": "keycloakdemoKeyCloakKeyCloakContainerSerivceTaskDef486F1059",
+        "Family": "keycloakdemoKeyCloakKeyCloakContainerServiceTaskDef3C4C2CF7",
         "Memory": "30720",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": Array [
@@ -716,14 +716,14 @@ Object {
         ],
         "TaskRoleArn": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceTaskDefTaskRole0DC4D418",
+            "KeyCloakKeyCloakContainerServiceTaskDefTaskRole509DDBD7",
             "Arn",
           ],
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
-    "KeyCloakKeyCloakContainerSerivceTaskDefTaskRole0DC4D418": Object {
+    "KeyCloakKeyCloakContainerServiceTaskDefTaskRole509DDBD7": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -740,7 +740,56 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "KeyCloakKeyCloakContainerSerivceTaskRole0658CED2": Object {
+    "KeyCloakKeyCloakContainerServiceTaskRoleDefaultPolicy41C39151": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "KeyCloakKeyCloakContainerServiceLogGroup770A4A22",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "KeyCloakDatabaseAuroraServerlessClusterSecretAttachmentA32F9C7B",
+              },
+            },
+            Object {
+              "Action": Array [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "KeyCloakKCSecretF8498E5C",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "KeyCloakKeyCloakContainerServiceTaskRoleDefaultPolicy41C39151",
+        "Roles": Array [
+          Object {
+            "Ref": "KeyCloakKeyCloakContainerServiceTaskRoleE227375A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "KeyCloakKeyCloakContainerServiceTaskRoleE227375A": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -773,55 +822,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "KeyCloakKeyCloakContainerSerivceTaskRoleDefaultPolicyA2321E87": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "KeyCloakDatabaseAuroraServerlessClusterSecretAttachmentA32F9C7B",
-              },
-            },
-            Object {
-              "Action": Array [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "KeyCloakKCSecretF8498E5C",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "KeyCloakKeyCloakContainerSerivceTaskRoleDefaultPolicyA2321E87",
-        "Roles": Array [
-          Object {
-            "Ref": "KeyCloakKeyCloakContainerSerivceTaskRole0658CED2",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "KeyCloakVpcF3901B3A": Object {
       "Properties": Object {

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -1,7 +1,10 @@
+import { stringLike } from '@aws-cdk/assert';
 import { App, Stack } from '@aws-cdk/core';
-import * as kc from '../src';
 import '@aws-cdk/assert/jest';
+
+import * as kc from '../src';
 import { KeycloakVersion } from '../src';
+
 test('create the default cluster', () => {
 
   // GIVEN
@@ -38,7 +41,7 @@ test('create the default cluster', () => {
     VpcSecurityGroupIds: [
       {
         'Fn::GetAtt': [
-          'KeyCloakDatabaseDBClusterSecurityGroup843B4392',
+          stringLike('KeyCloakDatabaseDBClusterSecurityGroup*'),
           'GroupId',
         ],
       },
@@ -51,7 +54,7 @@ test('create the default cluster', () => {
   // we should have ecs service
   expect(stack).toHaveResource('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: stringLike('KeyCloakKeyCloakContainerServiceCluster*'),
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -66,7 +69,7 @@ test('create the default cluster', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8443,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: stringLike('KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup*'),
         },
       },
     ],
@@ -76,23 +79,23 @@ test('create the default cluster', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              stringLike('KeyCloakKeyCloakContainerServiceSecurityGroup*'),
               'GroupId',
             ],
           },
         ],
         Subnets: [
           {
-            Ref: 'KeyCloakVpcPrivateSubnet1SubnetA692DFFF',
+            Ref: stringLike('KeyCloakVpcPrivateSubnet1Subnet*'),
           },
           {
-            Ref: 'KeyCloakVpcPrivateSubnet2SubnetC8682D75',
+            Ref: stringLike('KeyCloakVpcPrivateSubnet2Subnet*'),
           },
         ],
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: stringLike('KeyCloakKeyCloakContainerServiceTaskDef*'),
     },
   });
 });
@@ -123,7 +126,7 @@ test('with aurora serverless', () => {
   // we should have ecs service
   expect(stack).toHaveResource('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: stringLike('KeyCloakKeyCloakContainerServiceCluster*'),
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -138,7 +141,7 @@ test('with aurora serverless', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8443,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: stringLike('KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup*'),
         },
       },
     ],
@@ -148,23 +151,23 @@ test('with aurora serverless', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              stringLike('KeyCloakKeyCloakContainerServiceSecurityGroup*'),
               'GroupId',
             ],
           },
         ],
         Subnets: [
           {
-            Ref: 'KeyCloakVpcPrivateSubnet1SubnetA692DFFF',
+            Ref: stringLike('KeyCloakVpcPrivateSubnet1Subnet*'),
           },
           {
-            Ref: 'KeyCloakVpcPrivateSubnet2SubnetC8682D75',
+            Ref: stringLike('KeyCloakVpcPrivateSubnet2Subnet*'),
           },
         ],
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: stringLike('KeyCloakKeyCloakContainerServiceTaskDef*'),
     },
   });
 });
@@ -193,7 +196,7 @@ test('with single rds instance', () => {
     CopyTagsToSnapshot: true,
     DBParameterGroupName: 'default.mysql8.0',
     DBSubnetGroupName: {
-      Ref: 'KeyCloakDatabaseDBInstanceSubnetGroup71BF616F',
+      Ref: stringLike('KeyCloakDatabaseDBInstanceSubnetGroup*'),
     },
     Engine: 'mysql',
     EngineVersion: '8.0.21',
@@ -214,7 +217,7 @@ test('with single rds instance', () => {
     VPCSecurityGroups: [
       {
         'Fn::GetAtt': [
-          'KeyCloakDatabaseDBInstanceSecurityGroupC897947D',
+          stringLike('KeyCloakDatabaseDBInstanceSecurityGroup*'),
           'GroupId',
         ],
       },
@@ -225,7 +228,7 @@ test('with single rds instance', () => {
   // we should have ecs service
   expect(stack).toHaveResource('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: stringLike('KeyCloakKeyCloakContainerServiceCluster*'),
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -240,7 +243,7 @@ test('with single rds instance', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8443,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: stringLike('KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup*'),
         },
       },
     ],
@@ -250,23 +253,23 @@ test('with single rds instance', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              stringLike('KeyCloakKeyCloakContainerServiceSecurityGroup*'),
               'GroupId',
             ],
           },
         ],
         Subnets: [
           {
-            Ref: 'KeyCloakVpcPrivateSubnet1SubnetA692DFFF',
+            Ref: stringLike('KeyCloakVpcPrivateSubnet1Subnet*'),
           },
           {
-            Ref: 'KeyCloakVpcPrivateSubnet2SubnetC8682D75',
+            Ref: stringLike('KeyCloakVpcPrivateSubnet2Subnet*'),
           },
         ],
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: stringLike('KeyCloakKeyCloakContainerServiceTaskDef*'),
     },
   });
 });
@@ -295,7 +298,7 @@ test('with env', () => {
             Name: 'DB_ADDR',
             Value: {
               'Fn::GetAtt': [
-                'KeyCloakDatabaseDBCluster06E9C0E1',
+                stringLike('KeyCloakDatabaseDBCluster*'),
                 'Endpoint.Address',
               ],
             },
@@ -332,7 +335,7 @@ test('with env', () => {
         Essential: true,
         Image: {
           'Fn::FindInMap': [
-            'KeyCloakKeyCloakContainerSerivceKeycloakImageMapF79EAEA3',
+            stringLike('KeyCloakKeyCloakContainerServiceKeycloakImageMap*'),
             {
               Ref: 'AWS::Partition',
             },
@@ -343,7 +346,7 @@ test('with env', () => {
           LogDriver: 'awslogs',
           Options: {
             'awslogs-group': {
-              Ref: 'KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE',
+              Ref: stringLike('KeyCloakKeyCloakContainerServiceLogGroup*'),
             },
             'awslogs-stream-prefix': 'keycloak',
             'awslogs-region': {
@@ -382,7 +385,7 @@ test('with env', () => {
                 '',
                 [
                   {
-                    Ref: 'KeyCloakDatabaseDBClusterSecretAttachment50401C92',
+                    Ref: stringLike('KeyCloakDatabaseDBClusterSecretAttachment*'),
                   },
                   ':password::',
                 ],
@@ -396,7 +399,7 @@ test('with env', () => {
                 '',
                 [
                   {
-                    Ref: 'KeyCloakKCSecretF8498E5C',
+                    Ref: stringLike('KeyCloakKCSecret*'),
                   },
                   ':username::',
                 ],
@@ -410,7 +413,7 @@ test('with env', () => {
                 '',
                 [
                   {
-                    Ref: 'KeyCloakKCSecretF8498E5C',
+                    Ref: stringLike('KeyCloakKCSecret*'),
                   },
                   ':password::',
                 ],
@@ -423,11 +426,11 @@ test('with env', () => {
     Cpu: '4096',
     ExecutionRoleArn: {
       'Fn::GetAtt': [
-        'KeyCloakKeyCloakContainerSerivceTaskRole0658CED2',
+        stringLike('KeyCloakKeyCloakContainerServiceTaskRole*'),
         'Arn',
       ],
     },
-    Family: 'testingstackKeyCloakKeyCloakContainerSerivceTaskDef799BAD5B',
+    Family: stringLike('testingstackKeyCloakKeyCloakContainerServiceTaskDef*'),
     Memory: '30720',
     NetworkMode: 'awsvpc',
     RequiresCompatibilities: [
@@ -435,7 +438,7 @@ test('with env', () => {
     ],
     TaskRoleArn: {
       'Fn::GetAtt': [
-        'KeyCloakKeyCloakContainerSerivceTaskDefTaskRole0DC4D418',
+        stringLike('KeyCloakKeyCloakContainerServiceTaskDefTaskRole*'),
         'Arn',
       ],
     },


### PR DESCRIPTION
Fixes #
- several typos, eg. KeyCloakContainerSerivce -> KeyCloakContainerService

Tests #
- use stringLike in snapshot test instead of hashes
