### PR TITLE
fix: aws-cdk-lib 2.80.0 dependencies since pr #201 and all failing unit tests since pr #195

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.64.0",
+      "version": "2.80.0",
       "type": "build"
     },
     {
@@ -102,7 +102,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.64.0",
+      "version": "^2.80.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -6,7 +6,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Pahud Hsieh',
   authorAddress: 'pahudnet@gmail.com',
   description: 'CDK construct library that allows you to create KeyCloak service on AWS in TypeScript or Python',
-  cdkVersion: '2.64.0',
+  cdkVersion: '2.80.0',
   jsiiFqn: 'projen.AwsCdkConstructLibrary',
   name: 'cdk-keycloak',
   majorVersion: 2,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.64.0",
+    "aws-cdk-lib": "^2.80.0",
     "constructs": "^10.0.5"
   },
   "keywords": [

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -22,7 +22,7 @@ Object {
         "Ref": "KeyCloakDatabaseAuroraServerlessClusterDB73D16F",
       },
     },
-    "KeyCloakKeyCloakContainerSerivceEndpointURL9C81E19A": Object {
+    "KeyCloakKeyCloakContainerServiceEndpointURL80FE66F9": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
@@ -30,7 +30,7 @@ Object {
             "https://",
             Object {
               "Fn::GetAtt": Array [
-                "KeyCloakKeyCloakContainerSerivceALBE100B67D",
+                "KeyCloakKeyCloakContainerServiceALBF769E7D3",
                 "DNSName",
               ],
             },
@@ -163,9 +163,9 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4FIndirectPortF24A4E85": Object {
+    "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FEDIndirectPortCEAF978C": Object {
       "Properties": Object {
-        "Description": "from keycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F:{IndirectPort}",
+        "Description": "from keycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED:{IndirectPort}",
         "FromPort": Object {
           "Fn::GetAtt": Array [
             "KeyCloakDatabaseAuroraServerlessClusterDB73D16F",
@@ -181,7 +181,7 @@ Object {
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -223,7 +223,7 @@ Object {
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
-    "KeyCloakKeyCloakContainerSerivceALBE100B67D": Object {
+    "KeyCloakKeyCloakContainerServiceALBF769E7D3": Object {
       "DependsOn": Array [
         "KeyCloakVpcPublicSubnet1DefaultRoute438FBE69",
         "KeyCloakVpcPublicSubnet1RouteTableAssociationFF91B678",
@@ -241,7 +241,7 @@ Object {
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
-              "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6",
+              "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F",
               "GroupId",
             ],
           },
@@ -258,7 +258,7 @@ Object {
       },
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
     },
-    "KeyCloakKeyCloakContainerSerivceALBHttpsListener140F85B9": Object {
+    "KeyCloakKeyCloakContainerServiceALBHttpsListener6BFECEEA": Object {
       "Properties": Object {
         "Certificates": Array [
           Object {
@@ -268,20 +268,20 @@ Object {
         "DefaultActions": Array [
           Object {
             "TargetGroupArn": Object {
-              "Ref": "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C",
+              "Ref": "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774",
             },
             "Type": "forward",
           },
         ],
         "LoadBalancerArn": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceALBE100B67D",
+          "Ref": "KeyCloakKeyCloakContainerServiceALBF769E7D3",
         },
         "Port": 443,
         "Protocol": "HTTPS",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
-    "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C": Object {
+    "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774": Object {
       "Properties": Object {
         "HealthyThresholdCount": 3,
         "Port": 8443,
@@ -311,9 +311,9 @@ Object {
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6": Object {
+    "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F": Object {
       "Properties": Object {
-        "GroupDescription": "Automatically created Security Group for ELB keycloakdemoKeyCloakKeyCloakContainerSerivceALBA5C1F684",
+        "GroupDescription": "Automatically created Security Group for ELB keycloakdemoKeyCloakKeyCloakContainerServiceALBB2622B2D",
         "SecurityGroupIngress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -329,19 +329,19 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "KeyCloakKeyCloakContainerSerivceALBSecurityGrouptokeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F84431D27BEE9": Object {
+    "KeyCloakKeyCloakContainerServiceALBSecurityGrouptokeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED8443B9DE516C": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "FromPort": 8443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6",
+            "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F",
             "GroupId",
           ],
         },
@@ -350,42 +350,14 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "KeyCloakKeyCloakContainerSerivceClusterA18E44FF": Object {
+    "KeyCloakKeyCloakContainerServiceB78EDF48": Object {
       "DependsOn": Array [
-        "KeyCloakDatabaseAuroraServerlessClusterDB73D16F",
-        "KeyCloakDatabaseAuroraServerlessClusterSecretAttachmentA32F9C7B",
-        "keycloakdemoKeyCloakDatabaseAuroraServerlessClusterSecretBBC2EF3A3fdaad7efa858a3daf9490cf0a702aeb",
-        "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakDatabaseAuroraServerlessClusterSecurityGroup1CF1B8093306AB9B4528",
-        "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4FIndirectPortF24A4E85",
-        "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupF0CB4641",
-        "KeyCloakDatabaseAuroraServerlessClusterSubnets6166944B",
-      ],
-      "Properties": Object {
-        "ClusterSettings": Array [
-          Object {
-            "Name": "containerInsights",
-            "Value": "enabled",
-          },
-        ],
-      },
-      "Type": "AWS::ECS::Cluster",
-    },
-    "KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "RetentionInDays": 30,
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "KeyCloakKeyCloakContainerSerivceService79D3F427": Object {
-      "DependsOn": Array [
-        "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C",
-        "KeyCloakKeyCloakContainerSerivceALBHttpsListener140F85B9",
+        "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774",
+        "KeyCloakKeyCloakContainerServiceALBHttpsListener6BFECEEA",
       ],
       "Properties": Object {
         "Cluster": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceClusterA18E44FF",
+          "Ref": "KeyCloakKeyCloakContainerServiceCluster4583BCAE",
         },
         "DeploymentConfiguration": Object {
           "MaximumPercent": 200,
@@ -400,7 +372,7 @@ Object {
             "ContainerName": "keycloak",
             "ContainerPort": 8443,
             "TargetGroupArn": Object {
-              "Ref": "KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C",
+              "Ref": "KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774",
             },
           },
         ],
@@ -410,7 +382,7 @@ Object {
             "SecurityGroups": Array [
               Object {
                 "Fn::GetAtt": Array [
-                  "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+                  "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
                   "GroupId",
                 ],
               },
@@ -426,14 +398,42 @@ Object {
           },
         },
         "TaskDefinition": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceTaskDef30C9533A",
+          "Ref": "KeyCloakKeyCloakContainerServiceTaskDef6AD61714",
         },
       },
       "Type": "AWS::ECS::Service",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D": Object {
+    "KeyCloakKeyCloakContainerServiceCluster4583BCAE": Object {
+      "DependsOn": Array [
+        "KeyCloakDatabaseAuroraServerlessClusterDB73D16F",
+        "KeyCloakDatabaseAuroraServerlessClusterSecretAttachmentA32F9C7B",
+        "keycloakdemoKeyCloakDatabaseAuroraServerlessClusterSecretBBC2EF3A3fdaad7efa858a3daf9490cf0a702aeb",
+        "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakDatabaseAuroraServerlessClusterSecurityGroup1CF1B8093306AB9B4528",
+        "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FEDIndirectPortCEAF978C",
+        "KeyCloakDatabaseAuroraServerlessClusterSecurityGroupF0CB4641",
+        "KeyCloakDatabaseAuroraServerlessClusterSubnets6166944B",
+      ],
       "Properties": Object {
-        "GroupDescription": "keycloak-demo/KeyCloak/KeyCloakContainerSerivce/Service/SecurityGroup",
+        "ClusterSettings": Array [
+          Object {
+            "Name": "containerInsights",
+            "Value": "enabled",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "KeyCloakKeyCloakContainerServiceLogGroup770A4A22": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 30,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A": Object {
+      "Properties": Object {
+        "GroupDescription": "keycloak-demo/KeyCloak/KeyCloakContainerService/Service/SecurityGroup",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -447,20 +447,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceALBSecurityGroup2467C3338443866EBF70": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceALBSecurityGroup67E092F7844342691A3B": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "FromPort": 8443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceALBSecurityGroup8F5103C6",
+            "KeyCloakKeyCloakContainerServiceALBSecurityGroup70C4484F",
             "GroupId",
           ],
         },
@@ -468,20 +468,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F57600A05C613E": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED576009361FCC7": Object {
       "Properties": Object {
         "Description": "kc jgroups-tcp-fd",
         "FromPort": 57600,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -489,20 +489,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4F76000EB755EF": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FED760084F83EAB": Object {
       "Properties": Object {
         "Description": "kc jgroups-tcp",
         "FromPort": 7600,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -510,20 +510,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4FUDP5420084C20A28": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FEDUDP54200C13840AE": Object {
       "Properties": Object {
         "Description": "kc jgroups-udp-fd",
         "FromPort": 54200,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "udp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -531,20 +531,20 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerSerivceServiceSecurityGroup4DE99C4FUDP552001CE4EB13": Object {
+    "KeyCloakKeyCloakContainerServiceSecurityGroupfromkeycloakdemoKeyCloakKeyCloakContainerServiceSecurityGroup17E82FEDUDP55200DCB1BF9D": Object {
       "Properties": Object {
         "Description": "kc jgroups-udp",
         "FromPort": 55200,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
         "IpProtocol": "udp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D",
+            "KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A",
             "GroupId",
           ],
         },
@@ -552,7 +552,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceTaskCountTarget0EDF86B3": Object {
+    "KeyCloakKeyCloakContainerServiceTaskCountTarget95167BD4": Object {
       "Properties": Object {
         "MaxCapacity": 10,
         "MinCapacity": 2,
@@ -562,12 +562,12 @@ Object {
             Array [
               "service/",
               Object {
-                "Ref": "KeyCloakKeyCloakContainerSerivceClusterA18E44FF",
+                "Ref": "KeyCloakKeyCloakContainerServiceCluster4583BCAE",
               },
               "/",
               Object {
                 "Fn::GetAtt": Array [
-                  "KeyCloakKeyCloakContainerSerivceService79D3F427",
+                  "KeyCloakKeyCloakContainerServiceB78EDF48",
                   "Name",
                 ],
               },
@@ -595,12 +595,12 @@ Object {
       },
       "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
     },
-    "KeyCloakKeyCloakContainerSerivceServiceTaskCountTargetCpuScaling1480DC0B": Object {
+    "KeyCloakKeyCloakContainerServiceTaskCountTargetCpuScalingB44CF87F": Object {
       "Properties": Object {
-        "PolicyName": "keycloakdemoKeyCloakKeyCloakContainerSerivceServiceTaskCountTargetCpuScaling6EF32B2A",
+        "PolicyName": "keycloakdemoKeyCloakKeyCloakContainerServiceTaskCountTargetCpuScaling8EE194F1",
         "PolicyType": "TargetTrackingScaling",
         "ScalingTargetId": Object {
-          "Ref": "KeyCloakKeyCloakContainerSerivceServiceTaskCountTarget0EDF86B3",
+          "Ref": "KeyCloakKeyCloakContainerServiceTaskCountTarget95167BD4",
         },
         "TargetTrackingScalingPolicyConfiguration": Object {
           "PredefinedMetricSpecification": Object {
@@ -611,7 +611,7 @@ Object {
       },
       "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
     },
-    "KeyCloakKeyCloakContainerSerivceTaskDef30C9533A": Object {
+    "KeyCloakKeyCloakContainerServiceTaskDef6AD61714": Object {
       "Properties": Object {
         "ContainerDefinitions": Array [
           Object {
@@ -660,7 +660,7 @@ Object {
               "LogDriver": "awslogs",
               "Options": Object {
                 "awslogs-group": Object {
-                  "Ref": "KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE",
+                  "Ref": "KeyCloakKeyCloakContainerServiceLogGroup770A4A22",
                 },
                 "awslogs-region": "us-east-1",
                 "awslogs-stream-prefix": "keycloak",
@@ -738,11 +738,11 @@ Object {
         "Cpu": "4096",
         "ExecutionRoleArn": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceTaskRole0658CED2",
+            "KeyCloakKeyCloakContainerServiceTaskRoleE227375A",
             "Arn",
           ],
         },
-        "Family": "keycloakdemoKeyCloakKeyCloakContainerSerivceTaskDef486F1059",
+        "Family": "keycloakdemoKeyCloakKeyCloakContainerServiceTaskDef3C4C2CF7",
         "Memory": "8192",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": Array [
@@ -750,14 +750,14 @@ Object {
         ],
         "TaskRoleArn": Object {
           "Fn::GetAtt": Array [
-            "KeyCloakKeyCloakContainerSerivceTaskDefTaskRole0DC4D418",
+            "KeyCloakKeyCloakContainerServiceTaskDefTaskRole509DDBD7",
             "Arn",
           ],
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
-    "KeyCloakKeyCloakContainerSerivceTaskDefTaskRole0DC4D418": Object {
+    "KeyCloakKeyCloakContainerServiceTaskDefTaskRole509DDBD7": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -774,7 +774,56 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "KeyCloakKeyCloakContainerSerivceTaskRole0658CED2": Object {
+    "KeyCloakKeyCloakContainerServiceTaskRoleDefaultPolicy41C39151": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "KeyCloakKeyCloakContainerServiceLogGroup770A4A22",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "KeyCloakDatabaseAuroraServerlessClusterSecretAttachmentA32F9C7B",
+              },
+            },
+            Object {
+              "Action": Array [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "KeyCloakKCSecretF8498E5C",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "KeyCloakKeyCloakContainerServiceTaskRoleDefaultPolicy41C39151",
+        "Roles": Array [
+          Object {
+            "Ref": "KeyCloakKeyCloakContainerServiceTaskRoleE227375A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "KeyCloakKeyCloakContainerServiceTaskRoleE227375A": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -811,55 +860,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "KeyCloakKeyCloakContainerSerivceTaskRoleDefaultPolicyA2321E87": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "KeyCloakDatabaseAuroraServerlessClusterSecretAttachmentA32F9C7B",
-              },
-            },
-            Object {
-              "Action": Array [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "KeyCloakKCSecretF8498E5C",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "KeyCloakKeyCloakContainerSerivceTaskRoleDefaultPolicyA2321E87",
-        "Roles": Array [
-          Object {
-            "Ref": "KeyCloakKeyCloakContainerSerivceTaskRole0658CED2",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "KeyCloakVpcF3901B3A": Object {
       "Properties": Object {

--- a/test/cluster-quarkus.test.ts
+++ b/test/cluster-quarkus.test.ts
@@ -21,7 +21,7 @@ test('create the default cluster', () => {
     DBSubnetGroupName: {
       Ref: 'KeyCloakDatabaseDBClusterSubnetsE36F1B1B',
     },
-    EngineVersion: '5.7.mysql_aurora.2.09.1',
+    EngineVersion: '5.7.mysql_aurora.2.11.2',
     MasterUsername: 'admin',
     MasterUserPassword: {
       'Fn::Join': [
@@ -48,7 +48,7 @@ test('create the default cluster', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -63,7 +63,7 @@ test('create the default cluster', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8080,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -73,7 +73,7 @@ test('create the default cluster', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -89,7 +89,7 @@ test('create the default cluster', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -120,7 +120,7 @@ test('with aurora serverless', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -135,7 +135,7 @@ test('with aurora serverless', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8080,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -145,7 +145,7 @@ test('with aurora serverless', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -161,7 +161,7 @@ test('with aurora serverless', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -221,7 +221,7 @@ test('with aurora serverless v2', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -236,7 +236,7 @@ test('with aurora serverless v2', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8080,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -246,7 +246,7 @@ test('with aurora serverless v2', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -262,7 +262,7 @@ test('with aurora serverless v2', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -320,7 +320,7 @@ test('with single rds instance', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -335,7 +335,7 @@ test('with single rds instance', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8080,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -345,7 +345,7 @@ test('with single rds instance', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -361,7 +361,7 @@ test('with single rds instance', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -436,7 +436,7 @@ test('with env', () => {
         Essential: true,
         Image: {
           'Fn::FindInMap': [
-            'KeyCloakKeyCloakContainerSerivceKeycloakImageMapF79EAEA3',
+            'KeyCloakKeyCloakContainerServiceKeycloakImageMapE15D4544',
             {
               Ref: 'AWS::Partition',
             },
@@ -447,7 +447,7 @@ test('with env', () => {
           LogDriver: 'awslogs',
           Options: {
             'awslogs-group': {
-              Ref: 'KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE',
+              Ref: 'KeyCloakKeyCloakContainerServiceLogGroup770A4A22',
             },
             'awslogs-stream-prefix': 'keycloak',
             'awslogs-region': {
@@ -518,14 +518,14 @@ test('with env', () => {
     ],
     Cpu: '4096',
     ExecutionRoleArn: {
-      'Fn::GetAtt': ['KeyCloakKeyCloakContainerSerivceTaskRole0658CED2', 'Arn'],
+      'Fn::GetAtt': ['KeyCloakKeyCloakContainerServiceTaskRoleE227375A', 'Arn'],
     },
-    Family: 'testingstackKeyCloakKeyCloakContainerSerivceTaskDef799BAD5B',
+    Family: 'testingstackKeyCloakKeyCloakContainerServiceTaskDef1B636EF3',
     Memory: '8192',
     NetworkMode: 'awsvpc',
     RequiresCompatibilities: ['FARGATE'],
     TaskRoleArn: {
-      'Fn::GetAtt': ['KeyCloakKeyCloakContainerSerivceTaskDefTaskRole0DC4D418', 'Arn'],
+      'Fn::GetAtt': ['KeyCloakKeyCloakContainerServiceTaskDefTaskRole509DDBD7', 'Arn'],
     },
   });
 });

--- a/test/cluster-wildfly.test.ts
+++ b/test/cluster-wildfly.test.ts
@@ -22,7 +22,7 @@ test('create the default cluster', () => {
     DBSubnetGroupName: {
       Ref: 'KeyCloakDatabaseDBClusterSubnetsE36F1B1B',
     },
-    EngineVersion: '5.7.mysql_aurora.2.09.1',
+    EngineVersion: '5.7.mysql_aurora.2.11.2',
     MasterUsername: 'admin',
     MasterUserPassword: {
       'Fn::Join': [
@@ -52,7 +52,7 @@ test('create the default cluster', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -67,7 +67,7 @@ test('create the default cluster', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8443,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -77,7 +77,7 @@ test('create the default cluster', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -93,7 +93,7 @@ test('create the default cluster', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -125,7 +125,7 @@ test('with aurora serverless', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -140,7 +140,7 @@ test('with aurora serverless', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8443,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -150,7 +150,7 @@ test('with aurora serverless', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -166,7 +166,7 @@ test('with aurora serverless', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -230,7 +230,7 @@ test('with aurora serverless v2', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -245,7 +245,7 @@ test('with aurora serverless v2', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8443,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -255,7 +255,7 @@ test('with aurora serverless v2', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -271,7 +271,7 @@ test('with aurora serverless v2', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -333,7 +333,7 @@ test('with single rds instance', () => {
   // we should have ecs service
   t.hasResourceProperties('AWS::ECS::Service', {
     Cluster: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceClusterA18E44FF',
+      Ref: 'KeyCloakKeyCloakContainerServiceCluster4583BCAE',
     },
     DeploymentConfiguration: {
       MaximumPercent: 200,
@@ -348,7 +348,7 @@ test('with single rds instance', () => {
         ContainerName: 'keycloak',
         ContainerPort: 8443,
         TargetGroupArn: {
-          Ref: 'KeyCloakKeyCloakContainerSerivceALBHttpsListenerECSTargetGroupCE3EF52C',
+          Ref: 'KeyCloakKeyCloakContainerServiceALBHttpsListenerECSTargetGroup65B43774',
         },
       },
     ],
@@ -358,7 +358,7 @@ test('with single rds instance', () => {
         SecurityGroups: [
           {
             'Fn::GetAtt': [
-              'KeyCloakKeyCloakContainerSerivceServiceSecurityGroup4C80023D',
+              'KeyCloakKeyCloakContainerServiceSecurityGroup7433DA3A',
               'GroupId',
             ],
           },
@@ -374,7 +374,7 @@ test('with single rds instance', () => {
       },
     },
     TaskDefinition: {
-      Ref: 'KeyCloakKeyCloakContainerSerivceTaskDef30C9533A',
+      Ref: 'KeyCloakKeyCloakContainerServiceTaskDef6AD61714',
     },
   });
 });
@@ -445,7 +445,7 @@ test('with env', () => {
         Essential: true,
         Image: {
           'Fn::FindInMap': [
-            'KeyCloakKeyCloakContainerSerivceKeycloakImageMapF79EAEA3',
+            'KeyCloakKeyCloakContainerServiceKeycloakImageMapE15D4544',
             {
               Ref: 'AWS::Partition',
             },
@@ -456,7 +456,7 @@ test('with env', () => {
           LogDriver: 'awslogs',
           Options: {
             'awslogs-group': {
-              Ref: 'KeyCloakKeyCloakContainerSerivceLogGroup010F2AAE',
+              Ref: 'KeyCloakKeyCloakContainerServiceLogGroup770A4A22',
             },
             'awslogs-stream-prefix': 'keycloak',
             'awslogs-region': {
@@ -536,11 +536,11 @@ test('with env', () => {
     Cpu: '4096',
     ExecutionRoleArn: {
       'Fn::GetAtt': [
-        'KeyCloakKeyCloakContainerSerivceTaskRole0658CED2',
+        'KeyCloakKeyCloakContainerServiceTaskRoleE227375A',
         'Arn',
       ],
     },
-    Family: 'testingstackKeyCloakKeyCloakContainerSerivceTaskDef799BAD5B',
+    Family: 'testingstackKeyCloakKeyCloakContainerServiceTaskDef1B636EF3',
     Memory: '8192',
     NetworkMode: 'awsvpc',
     RequiresCompatibilities: [
@@ -548,7 +548,7 @@ test('with env', () => {
     ],
     TaskRoleArn: {
       'Fn::GetAtt': [
-        'KeyCloakKeyCloakContainerSerivceTaskDefTaskRole0DC4D418',
+        'KeyCloakKeyCloakContainerServiceTaskDefTaskRole509DDBD7',
         'Arn',
       ],
     },


### PR DESCRIPTION
Fixes #
- Dependencies to aws-cdk-lib in version 2.80.0 fixed
- Unit tests related to updated aurora version fixed
- Unit tests related to aws-cdk-lib 2.80.0 fixed